### PR TITLE
Loader manquant

### DIFF
--- a/docs/authentication/logout.md
+++ b/docs/authentication/logout.md
@@ -20,6 +20,8 @@ Dans le cas de la d√©connexion, pas besoin de front, nous pouvons simplement cr√
   <summary>Voir une solution</summary>
 
 ```tsx title="app/routes/api.logout.ts"
+export const loader = () => { return null; }
+  
 export const action = async ({ request }: ActionArgs) => {
   const session = await getSession(request.headers.get("Cookie"));
   return redirect("/", {


### PR DESCRIPTION
A l'étape "Déconnexion" il manque un loader pour pouvoir faire fpnctionner la route /api/logout. Sinon on a cette erreur : 
```
ErrorResponse {
  status: 400,
  statusText: 'Bad Request',
  internal: true,
  data: 'Error: You made a GET request to "/api/logout" but did not provide a `loader` for route "routes/api.logout", so there is no way to handle the request.',
  error: Error: You made a GET request to "/api/logout" but did not provide a `loader` for route "routes/api.logout", so there is no way to handle the request.
      at getInternalRouterError (/Users/alex/dev/my-playlists/node_modules/@remix-run/router/router.ts:3507:5)
      at loadRouteData (/Users/alex/dev/my-playlists/node_modules/@remix-run/router/router.ts:2695:13)
      at queryImpl (/Users/alex/dev/my-playlists/node_modules/@remix-run/router/router.ts:2513:26)
      at Object.queryRoute (/Users/alex/dev/my-playlists/node_modules/@remix-run/router/router.ts:2453:24)
      at handleResourceRequestRR (/Users/alex/dev/my-playlists/node_modules/@remix-run/server-runtime/dist/server.js:240:40)
      at requestHandler (/Users/alex/dev/my-playlists/node_modules/@remix-run/server-runtime/dist/server.js:65:24)
      at /Users/alex/dev/my-playlists/node_modules/@remix-run/express/dist/server.js:39:28
      at /Users/alex/dev/my-playlists/node_modules/@remix-run/serve/dist/index.js:47:7
      at Layer.handle [as handle_request] (/Users/alex/dev/my-playlists/node_modules/express/lib/router/layer.js:95:5)
      at next (/Users/alex/dev/my-playlists/node_modules/express/lib/router/route.js:144:13)
}
GET /api/logout 500 - - 6.346 ms
```
